### PR TITLE
Add LICENSE and project documentation under /docs

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2025 Marcos Paulo Pazzinatto
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights  
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell      
+copies of the Software, and to permit persons to whom the Software is         
+furnished to do so, subject to the following conditions:                       
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.                                
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR     
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,       
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE    
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER         
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,  
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE  
+SOFTWARE.
+

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,23 @@
+# Project Overview
+
+## Project Name
+Temperature and Humidity Meter
+
+## Summary
+This project monitors temperature and humidity using the HTU21D sensor connected to a MicroPython board. Based on the sensor readings, it provides visual feedback through four discrete LEDs (temperature levels) and one RGB LED (humidity status). It's ideal for educational purposes and for integrating into environments like smart trailers or off-grid systems.
+
+## Motivation
+The goal of this project is to create a simple yet effective way to visually track environmental conditions using common electronic components and MicroPython.
+
+## How it Works
+- The HTU21D sensor communicates via I2C.
+- Temperature thresholds activate one or more discrete LEDs to represent temperature levels.
+- Humidity ranges are color-coded using an RGB LED.
+- The system runs continuously in a loop, updating values in real-time.
+
+## Application Examples
+- Embedded systems education
+- Smart trailer environment monitoring
+- Home IoT temperature/humidity tracking
+- Off-grid or mobile sensor stations
+


### PR DESCRIPTION
This pull request adds the initial documentation and licensing files for the Temperature and Humidity Meter project.

**Changes included:**
- Added `LICENSE` file (MIT License by default, can be adjusted if needed)
- Created `docs/overview.md` with detailed explanation of the project structure, goals, usage, and applications

These additions help formalize the project structure and provide essential context for contributors and users.
